### PR TITLE
Dockerfile: remove gcc deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM infosiftr/buildpack-deps
 RUN apt-get update && apt-get install -y \
 		ca-certificates \
 		curl \
-		g++ \
-		gcc \
-		make \
 		openssl \
 		procps \
 		python


### PR DESCRIPTION
As it is included in the base image (through build-essential)
