### PR TITLE
Add update.sh script to easily update all the versions we support

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+versions=( "$@" )
+if [ ${#versions[@]} -eq 0 ]; then
+	versions=( */ )
+fi
+versions=( "${versions[@]%/}" )
+
+for version in "${versions[@]}"; do
+	fullVersion="$(curl -sSL 'http://nodejs.org/dist' | grep '<a href="v'"$version." | sed -r 's!.*<a href="v([^"/]+)/?".*!\1!' | sort -V | tail -1)"
+	(
+		set -x
+		sed -ri 's/^(ENV NODE_VERSION) .*/\1 '"$fullVersion"'/' "$version/Dockerfile"
+	)
+done


### PR DESCRIPTION
Output looks like:

``` console
$ ./update.sh
+ sed -ri 's/^(ENV NODE_VERSION ).*/\10.10.30/' 0.10/Dockerfile
+ sed -ri 's/^(ENV NODE_VERSION ).*/\10.11.13/' 0.11/Dockerfile
+ sed -ri 's/^(ENV NODE_VERSION ).*/\10.8.28/' 0.8/Dockerfile
```
